### PR TITLE
Feature/add new test fixture to unit tests

### DIFF
--- a/packages/testing/dataplattform/testing/plugin.py
+++ b/packages/testing/dataplattform/testing/plugin.py
@@ -132,8 +132,13 @@ def create_table_mock(mocker):
             check_names=False,
             **kwargs)
 
+    def assert_table_data_contains_df(table, df, **kwargs):
+        tmp_df = df.isin(df_from_calls(f'structured/{table}'))
+        assert tmp_df.eq(True).all().all() 
+
     on_to_parquet_stub.assert_table_created = assert_table_created
     on_to_parquet_stub.assert_table_data = assert_table_data
     on_to_parquet_stub.assert_table_data_column = assert_table_data_column
+    on_to_parquet_stub.assert_table_data_contains_df = assert_table_data_contains_df
 
     yield on_to_parquet_stub

--- a/services/ingestion/poller/yrWeather/test_yr_poller.py
+++ b/services/ingestion/poller/yrWeather/test_yr_poller.py
@@ -3,6 +3,7 @@ from pytest import fixture
 from responses import RequestsMock, GET
 from json import loads
 from os import path
+import pandas as pd
 
 location = 'Norway/Oslo/Oslo/Lakkegata'
 url = f'https://www.yr.no/place/{location}/varsel_time_for_time.xml'
@@ -58,3 +59,13 @@ def test_handler_data(s3_bucket, mocked_responses, test_data):
     }
 
     assert all([data['data'][0][k] == v for k, v in expected.items()])
+
+
+def test_hander_process_data(s3_bucket, mocked_responses, test_data, create_table_mock):
+    mocked_responses.add(GET, url, body=test_data, status=200)
+
+    handler(None, None)
+    create_table_mock.assert_table_data_column(
+        'yr_weather',
+        'location',
+        pd.Series(['Norway/Oslo/Oslo/Lakkegata']*24))

--- a/services/ingestion/webHooks/jiraSales/test_jira_webhook.py
+++ b/services/ingestion/webHooks/jiraSales/test_jira_webhook.py
@@ -1,6 +1,7 @@
 from jira_webhook import handler
 from dataplattform.testing.events import APIGateway
 from json import dumps, loads
+import pandas as pd
 
 
 def test_invalid():
@@ -56,3 +57,33 @@ def test_insert_data(s3_bucket):
     assert data['data']['issue'] == 'TEST-1234' and\
         data['data']['customer'] == 'Test Testerson' and\
         data['data']['issue_status'] == 'Open'
+
+
+def test_handler_process(s3_bucket, create_table_mock):
+    handler(APIGateway(
+        path_parameters={
+            'secret': 'iamsecret'
+        },
+        body=dumps({
+            'webhookEvent': 'jira:issue_created',
+            'issue': {
+                'key': 'TEST-1234',
+                'fields': {
+                    'created': '2020-01-01T00:00:00.000-0000',
+                    'updated': '2020-01-01T00:00:00.000-0000',
+                    'status': {'name': 'Open'},
+                    'labels': ['Test Testerson'],
+                }
+            }
+        })
+    ).to_dict())
+
+    create_table_mock.assert_table_data_column(
+        'jira_issue_created',
+        'issue_status',
+        pd.Series(['Open']))
+
+    create_table_mock.assert_table_data_column(
+        'jira_issue_created',
+        'customer',
+        pd.Series(['Test Testerson']))


### PR DESCRIPTION
Før så ble det satt opp en hook til `on_parquet` som så testet at dataen så OK ut. Disse testene ble som et resultat bare gyldige dersom  `on_parquet`  blir kallt. Om man innfører en breaking change som gjør at  `on_parquet`  ikke blir kallt ville testene fortsatt gå igjennom. Dette er nå fikset ved å sjekke det faktisk innholdet i de strukturerte dataene. 